### PR TITLE
Use correct @Target for LabelBlockLookup.Parameter

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookup.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookup.kt
@@ -28,7 +28,7 @@ interface LabelBlockLookup {
 	 *
 	 */
 	@Retention(AnnotationRetention.RUNTIME)
-	@Target(AnnotationTarget.PROPERTY)
+	@Target(AnnotationTarget.FIELD)
 	@Inherited
 	annotation class Parameter
 


### PR DESCRIPTION
Fixes #4

See also saalfeldlab/paintera#232

Will have to make sure that the other use cases of the `@Parameter` annotation still work as expected:

 - [x] [`LabelBlockLookupFromFile`](https://github.com/saalfeldlab/label-utilities/blob/ab602f3c730912593ed24e15822491174f0aae24/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookupFromFile.kt#L17)
 - [x] [`LabelBlockLookupFromN5`](https://github.com/saalfeldlab/label-utilities-n5/blob/08f3065cb4e283af24b0f9feb857dae703a9ed57/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/n5/LabelBlockLookupFromN5.kt#L19-L21)