### PR TITLE
Use imglib2 cache for block lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /target
 *.swp
 *_completion
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+dist: trusty
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
 		<url>https://travis-ci.org/saalfeldlab/label-utilities</url>
 	</ciManagement>
 
-
 	<properties>
+		<package-name>org.janelia.saalfeldlab</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
 		<imglib2-algorithm.version>0.10.0</imglib2-algorithm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
@@ -81,6 +81,8 @@
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<imglib2-cache.version>1.0.0-beta-13</imglib2-cache.version>
 	</properties>
 
 	<repositories>
@@ -110,6 +112,10 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-algorithm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-cache</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/CachedLabelBlockLookup.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/CachedLabelBlockLookup.kt
@@ -1,0 +1,5 @@
+package org.janelia.saalfeldlab.labels.blocks
+
+import net.imglib2.cache.Invalidate
+
+interface CachedLabelBlockLookup : LabelBlockLookup, Invalidate<LabelBlockLookupKey>

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookup.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookup.kt
@@ -8,10 +8,10 @@ import java.lang.annotation.Inherited
 interface LabelBlockLookup {
 
 	@Throws(IOException::class)
-	fun read(level: Int, id: Long): Array<Interval>
+	fun read(key: LabelBlockLookupKey): Array<Interval>
 
 	@Throws(IOException::class)
-	fun write(level: Int, id: Long, vararg intervals: Interval)
+	fun write(key: LabelBlockLookupKey, vararg intervals: Interval)
 
 	/**
 	 * Annotation for runtime discovery of compression schemes.

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookupKey.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookupKey.kt
@@ -1,3 +1,3 @@
 package org.janelia.saalfeldlab.labels.blocks
 
-class LabelBlockLookupKey(val level: Int, val id: Long)
+data class LabelBlockLookupKey(val level: Int, val id: Long)

--- a/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookupKey.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/labels/blocks/LabelBlockLookupKey.kt
@@ -1,0 +1,3 @@
+package org.janelia.saalfeldlab.labels.blocks
+
+class LabelBlockLookupKey(val level: Int, val id: Long)


### PR DESCRIPTION
* Add `CachedLabelBlockLookup` interface: implementations of label-to-block lookup are now expected to provide caching functionality by themselves if appropriate
* Add imglib2-based `SoftRefCache` to file-based lookup implementation

(this is part of https://github.com/saalfeldlab/paintera/pull/267)